### PR TITLE
Exposes option for loader on payment element

### DIFF
--- a/src/lib/PaymentElement.svelte
+++ b/src/lib/PaymentElement.svelte
@@ -22,7 +22,12 @@
   /** @type {Appearance["labels"]} */
   export let labels = 'above'
 
-  export let elements = isServer ? null : stripe.elements({ appearance: { theme, variables, rules, labels }, clientSecret })
+  /** @typedef { import('@stripe/stripe-js').StripeElementsOptions } StripeElementsOptions */
+
+  /** @type {StripeElementsOptions["loader"]} */
+  export let loader = 'auto'
+
+  export let elements = isServer ? null : stripe.elements({ appearance: { theme, variables, rules, labels }, clientSecret, loader })
 
   /** @type {import('@stripe/stripe-js').StripeElementBase} */
   let element


### PR DESCRIPTION
Stripe exposes an option to define the loading appearance of a select few elements (`payment`, `shippingAddress`, and `linkAuthentication`) as per the official docs [here](https://stripe.com/docs/js/elements_object/create#stripe_elements-options-loader).

This PR simply exposes the option on the PaymentElement svelte component.

Let me know if you have any feedback or requested changes. Thanks!