### PR TITLE
Added fonts option to Elements.svelte component

### DIFF
--- a/src/lib/Elements.svelte
+++ b/src/lib/Elements.svelte
@@ -24,13 +24,16 @@
   /** @type {StripeElementsOptions["loader"]} */
   export let loader = 'auto'
 
+  /** @type {StripeElementsOptions["fonts"]} */
+  export let fonts = []
+
   /** @type {string?} */
   export let clientSecret = undefined
 
   /** @type {import('@stripe/stripe-js').StripeElements?} */
   export let elements = isServer
     ? null
-    : stripe.elements({ appearance: { theme, variables, rules, labels }, clientSecret, loader })
+    : stripe.elements({ appearance: { theme, variables, rules, labels }, clientSecret, fonts, loader })
 
   register(stripe)
   setContext('stripe', { stripe, elements })


### PR DESCRIPTION
The `@stripe/stripe-js` package supports the option to define custom fonts in the Elements wrapper, which as far as I can see is the only way to get custom fonts working for individual Elements (`CardNumber`, `CardCvc`, etc.). This PR adds a `fonts` prop on the `Elements.svelte` component to give the option to pass in custom fonts.

Please let me know if any changes need to be made. Thanks!