### PR TITLE
Allow remounting components

### DIFF
--- a/src/lib/Address.svelte
+++ b/src/lib/Address.svelte
@@ -56,7 +56,7 @@
     }
     element = mount(wrapper, 'address', elements, dispatch, options)
 
-    return () => element.unmount()
+    return () => element.destroy()
   })
 
   export function blur() {

--- a/src/lib/Card.svelte
+++ b/src/lib/Card.svelte
@@ -39,7 +39,7 @@
 
     element = mount(wrapper, 'card', elements, dispatch, options)
 
-    return () => element.unmount()
+    return () => element.destroy()
   })
 
   export function blur() {

--- a/src/lib/CardCvc.svelte
+++ b/src/lib/CardCvc.svelte
@@ -30,7 +30,7 @@
 
     element = mount(wrapper, 'cardCvc', elements, dispatch, options)
 
-    return () => element.unmount()
+    return () => element.destroy()
   })
 
   export function blur() {

--- a/src/lib/CardExpiry.svelte
+++ b/src/lib/CardExpiry.svelte
@@ -30,7 +30,7 @@
 
     element = mount(wrapper, 'cardExpiry', elements, dispatch, options)
 
-    return () => element.unmount()
+    return () => element.destroy()
   })
 
   export function blur() {

--- a/src/lib/CardNumber.svelte
+++ b/src/lib/CardNumber.svelte
@@ -36,7 +36,7 @@
 
     element = mount(wrapper, 'cardNumber', elements, dispatch, options)
 
-    return () => element.unmount()
+    return () => element.destroy()
   })
 
   export function blur() {

--- a/src/lib/Iban.svelte
+++ b/src/lib/Iban.svelte
@@ -47,7 +47,7 @@
 
     element = mount(wrapper, 'iban', elements, dispatch, options)
 
-    return () => element.unmount()
+    return () => element.destroy()
   })
 
   export function blur() {

--- a/src/lib/Ideal.svelte
+++ b/src/lib/Ideal.svelte
@@ -33,7 +33,7 @@
 
     element = mount(wrapper, 'idealBank', elements, dispatch, options)
 
-    return () => element.unmount()
+    return () => element.destroy()
   })
 
   export function blur() {

--- a/src/lib/LinkAuthenticationElement.svelte
+++ b/src/lib/LinkAuthenticationElement.svelte
@@ -20,7 +20,7 @@
     const options = defaultValues ? { defaultValues } : {}
     element = mount(wrapper, 'linkAuthentication', elements, dispatch, options)
 
-    return () => element.unmount()
+    return () => element.destroy()
   })
 
   export function blur() {

--- a/src/lib/PaymentElement.svelte
+++ b/src/lib/PaymentElement.svelte
@@ -16,7 +16,7 @@
   onMount(() => {
     element = mount(wrapper, 'payment', elements, dispatch)
 
-    return () => element.unmount()
+    return () => element.destroy()
   })
 
   export function blur() {

--- a/src/lib/PaymentRequestButton.svelte
+++ b/src/lib/PaymentRequestButton.svelte
@@ -48,7 +48,7 @@
       wrapper.style.display = 'none'
     }
 
-    return () => element.unmount()
+    return () => element.destroy()
   })
 </script>
 


### PR DESCRIPTION
Elements were not able to be remounted and was causing an error:

```
Uncaught (in promise) IntegrationError: Can only create one Element of type payment.
```

This fixes it by destroying the Stripe component when the Svelte component is destroyed.

Fixes #60
