### PR TITLE
Support for Payment Element options.defaultValues & example to Payment Element section

### DIFF
--- a/src/lib/PaymentElement.svelte
+++ b/src/lib/PaymentElement.svelte
@@ -2,6 +2,8 @@
   import { onMount, getContext, createEventDispatcher } from 'svelte'
   import { mount } from './util'
 
+  /** @typedef {import('@stripe/stripe-js').StripePaymentElementOptions} StripePaymentElementOptions */
+
   /** @type {import('@stripe/stripe-js').StripeElementBase} */
   let element
 
@@ -13,8 +15,14 @@
   /** @type {import("./types").ElementsContext} */
   const { elements } = getContext('stripe')
 
+  /** @type {StripePaymentElementOptions["defaultValues"]} */
+  export let defaultValues
+
   onMount(() => {
-    element = mount(wrapper, 'payment', elements, dispatch)
+    const options = {
+      defaultValues
+    }
+    element = mount(wrapper, 'payment', elements, dispatch, options)
 
     return () => element.destroy()
   })

--- a/src/lib/PaymentElement.svelte
+++ b/src/lib/PaymentElement.svelte
@@ -15,13 +15,10 @@
   /** @type {import("./types").ElementsContext} */
   const { elements } = getContext('stripe')
 
-  /** @type {StripePaymentElementOptions["defaultValues"]} */
-  export let defaultValues
+  /** @type {StripePaymentElementOptions?} */
+  export let options
 
   onMount(() => {
-    const options = {
-      defaultValues
-    }
     element = mount(wrapper, 'payment', elements, dispatch, options)
 
     return () => element.destroy()

--- a/src/routes/+page.md
+++ b/src/routes/+page.md
@@ -107,33 +107,11 @@ To use it, drop a `<PaymentElement>` component in your form:
 ```html
 <form on:submit|preventDefault="{submit}">
   <Elements {stripe} {clientSecret} bind:elements>
-    <PaymentElement />
+    <PaymentElement options={...} />
   </Elements>
 
   <button>Pay</button>
 </form>
-```
-
-When you want to set default values as per the [Stripe Payment Element Options `defaultValues` object](https://stripe.com/docs/js/elements_object/create_payment_element#payment_element_create-options) you do so by the following:
-
-```Javascript
-const options = {
-  defaultValues: {
-    billingDetails: {
-      email: 'johnd@domain.com',
-      name: 'John Doe',
-      phone: '888-888-8888',
-      address: {
-        postal_code: '10001',
-        country: 'US',
-      }
-    },
-  }
-}
-```
-
-```html
-<PaymentElement options={options}  />
 ```
 
 Then when creating the payment intent, enable the `automatic_payment_methods:` option:

--- a/src/routes/+page.md
+++ b/src/routes/+page.md
@@ -114,6 +114,28 @@ To use it, drop a `<PaymentElement>` component in your form:
 </form>
 ```
 
+When you want to set default values as per the [Stripe Payment Element Options `defaultValues` object](https://stripe.com/docs/js/elements_object/create_payment_element#payment_element_create-options) you do so by the following:
+
+```Javascript
+const options = {
+  defaultValues: {
+    billingDetails: {
+      email: 'johnd@domain.com',
+      name: 'John Doe',
+      phone: '888-888-8888',
+      address: {
+        postal_code: '10001',
+        country: 'US',
+      }
+    },
+  }
+}
+```
+
+```html
+<PaymentElement options={options}  />
+```
+
 Then when creating the payment intent, enable the `automatic_payment_methods:` option:
 
 ```javascript


### PR DESCRIPTION
I have added the options array to the Payment Element ATM it is only accepting defaultValues. I will work on other PR for the rest of the objects which stripe accepts.

Typespec has also been added

Been wanting this for a while so I hope it is welcomed

Should solve #71 #68