### PR TITLE
Adds events to PaymentRequestButton

### DIFF
--- a/src/lib/PaymentRequestButton.svelte
+++ b/src/lib/PaymentRequestButton.svelte
@@ -37,12 +37,15 @@
     element = elements.create('paymentRequestButton', options)
     const result = await paymentRequestObject.canMakePayment()
 
+    paymentRequestObject.on('token', (e) => dispatch('token', e))
+    paymentRequestObject.on('cancel', (e) => dispatch('cancel', e))
+    paymentRequestObject.on('paymentmethod', (e) => dispatch('paymentmethod', e))
+    paymentRequestObject.on('shippingaddresschange', (e) => dispatch('shippingaddresschange', e))
+    paymentRequestObject.on('shippingoptionchange', (e) => dispatch('shippingoptionchange', e))
+
     if (result) {
       canMakePayment = true
       element.mount(wrapper)
-      paymentRequestObject.on('paymentmethod', (e) => {
-        dispatch('paymentmethod', e)
-      })
     } else {
       canMakePayment = false
       wrapper.style.display = 'none'


### PR DESCRIPTION
Adds missing events to `PaymentRequestButton`:

- `token`
- `cancel`
- `shippingaddresschange`
- `shippingoptionchange`

Closes #63
