### PR TITLE
feat: Remove need to wrap <Elements/> for SSR

### DIFF
--- a/src/lib/Elements.svelte
+++ b/src/lib/Elements.svelte
@@ -47,16 +47,20 @@
   }
 
   /** @type {import('@stripe/stripe-js').StripeElements?} */
-  export let elements = isServer
-    ? null
-    : stripe.elements({ mode, currency, amount, appearance, clientSecret, fonts, loader, locale })
+  export let elements = null
 
-  register(stripe)
-  setContext('stripe', { stripe, elements })
+  $: if (stripe) {
+    elements = stripe.elements({ mode, currency, amount, appearance, clientSecret, fonts, loader, locale })
+
+    register(stripe)
+    setContext('stripe', { stripe, elements })
+  }
 
   $: if (elements) {
     elements.update({ appearance, locale })
   }
 </script>
 
-<slot />
+{#if stripe && elements}
+  <slot />
+{/if}

--- a/src/routes/+page.md
+++ b/src/routes/+page.md
@@ -53,11 +53,9 @@ In your payment page, initialize Stripe and add a `<Elements>` component:
   })
 </script>
 
-{#if stripe}
 <Elements {stripe}>
   <!-- this is where your Stripe components go -->
 </Elements>
-{/if}
 ```
 
 ### Creating a payment intent

--- a/src/routes/examples/afterpay-clearpay/+page.svelte
+++ b/src/routes/examples/afterpay-clearpay/+page.svelte
@@ -97,28 +97,24 @@
   <p class="error">Payment failed. Please try again.</p>
 {/if}
 
-{#if stripe}
-  <form on:submit|preventDefault={submit}>
-    <Address legend="Billing" bind:address={billingAddress}>
-      <label for="name"> Name </label>
-      <input id="name" bind:value={name} required />
-      <label for="email"> Email </label>
-      <input type="email" id="email" bind:value={email} required />
-    </Address>
+<form on:submit|preventDefault={submit}>
+  <Address legend="Billing" bind:address={billingAddress}>
+    <label for="name"> Name </label>
+    <input id="name" bind:value={name} required />
+    <label for="email"> Email </label>
+    <input type="email" id="email" bind:value={email} required />
+  </Address>
 
-    <Address legend="Shipping" bind:address={shippingAddress} />
+  <Address legend="Shipping" bind:address={shippingAddress} />
 
-    <button disabled={processing}>
-      {#if processing}
-        Processing...
-      {:else}
-        Pay with Afterpay/Clearpay
-      {/if}
-    </button>
-  </form>
-{:else}
-  Loading...
-{/if}
+  <button disabled={processing}>
+    {#if processing}
+      Processing...
+    {:else}
+      Pay with Afterpay/Clearpay
+    {/if}
+  </button>
+</form>
 
 <style>
   .error {

--- a/src/routes/examples/alipay/+page.svelte
+++ b/src/routes/examples/alipay/+page.svelte
@@ -71,27 +71,23 @@
   <p class="error">Payment failed. Please try again.</p>
 {/if}
 
-{#if stripe}
-  <form on:submit|preventDefault={submit}>
-    <input
-      name="email"
-      bind:value={email}
-      placeholder="E-mail"
-      type="email"
-      disabled={processing}
-    />
+<form on:submit|preventDefault={submit}>
+  <input
+    name="email"
+    bind:value={email}
+    placeholder="E-mail"
+    type="email"
+    disabled={processing}
+  />
 
-    <button disabled={processing}>
-      {#if processing}
-        Processing...
-      {:else}
-        Pay with Alipay
-      {/if}
-    </button>
-  </form>
-{:else}
-  Loading...
-{/if}
+  <button disabled={processing}>
+    {#if processing}
+      Processing...
+    {:else}
+      Pay with Alipay
+    {/if}
+  </button>
+</form>
 
 <style>
   .error {

--- a/src/routes/examples/credit-card/+page.svelte
+++ b/src/routes/examples/credit-card/+page.svelte
@@ -67,29 +67,25 @@
   <p class="error">{error.message} Please try again.</p>
 {/if}
 
-{#if stripe}
-  <Elements {stripe}>
-    <form on:submit|preventDefault={submit}>
-      <input name="name" bind:value={name} placeholder="Your name" disabled={processing} />
-      <CardNumber bind:element={cardElement} classes={{ base: 'input' }} />
+<Elements {stripe}>
+  <form on:submit|preventDefault={submit}>
+    <input name="name" bind:value={name} placeholder="Your name" disabled={processing} />
+    <CardNumber bind:element={cardElement} classes={{ base: 'input' }} />
 
-      <div class="row">
-        <CardExpiry classes={{ base: 'input' }} />
-        <CardCvc classes={{ base: 'input' }} />
-      </div>
+    <div class="row">
+      <CardExpiry classes={{ base: 'input' }} />
+      <CardCvc classes={{ base: 'input' }} />
+    </div>
 
-      <button disabled={processing}>
-        {#if processing}
-          Processing...
-        {:else}
-          Pay
-        {/if}
-      </button>
-    </form>
-  </Elements>
-{:else}
-  Loading...
-{/if}
+    <button disabled={processing}>
+      {#if processing}
+        Processing...
+      {:else}
+        Pay
+      {/if}
+    </button>
+  </form>
+</Elements>
 
 <style>
   .error {

--- a/src/routes/examples/express-checkout/+page.svelte
+++ b/src/routes/examples/express-checkout/+page.svelte
@@ -94,26 +94,22 @@
   <p class="error">{error.message} Please try again.</p>
 {/if}
 
-{#if stripe}
-  <Elements
-    {stripe}
-    mode="payment"
-    currency="usd"
-    amount={1099}
-    bind:elements>
+<Elements
+  {stripe}
+  mode="payment"
+  currency="usd"
+  amount={1099}
+  bind:elements>
 
-    <ExpressCheckout
-      on:confirm={confirm}
-      on:click={click}
-      buttonHeight={50}
-      buttonTheme={{googlePay: 'white'}}
-      buttonType={{googlePay: 'donate'}}
-      paymentMethodOrder={['googlePay', 'link']}/>
+  <ExpressCheckout
+    on:confirm={confirm}
+    on:click={click}
+    buttonHeight={50}
+    buttonTheme={{googlePay: 'white'}}
+    buttonType={{googlePay: 'donate'}}
+    paymentMethodOrder={['googlePay', 'link']}/>
 
-  </Elements>
-{:else}
-  Loading...
-{/if}
+</Elements>
 
 <style>
   .error {

--- a/src/routes/examples/ideal/+page.svelte
+++ b/src/routes/examples/ideal/+page.svelte
@@ -81,31 +81,27 @@
   <p class="error">Payment failed. Please try again.</p>
 {/if}
 
-{#if stripe}
-  <Elements {stripe}>
-    <form on:submit|preventDefault={submit}>
-      <input name="name" bind:value={name} placeholder="Name" disabled={processing} />
-      <input
-        name="email"
-        bind:value={email}
-        placeholder="E-mail"
-        type="email"
-        disabled={processing}
-      />
-      <Ideal bind:element={idealElement} classes={{ base: 'input' }} />
+<Elements {stripe}>
+  <form on:submit|preventDefault={submit}>
+    <input name="name" bind:value={name} placeholder="Name" disabled={processing} />
+    <input
+      name="email"
+      bind:value={email}
+      placeholder="E-mail"
+      type="email"
+      disabled={processing}
+    />
+    <Ideal bind:element={idealElement} classes={{ base: 'input' }} />
 
-      <button disabled={processing}>
-        {#if processing}
-          Processing...
-        {:else}
-          Pay
-        {/if}
-      </button>
-    </form>
-  </Elements>
-{:else}
-  Loading...
-{/if}
+    <button disabled={processing}>
+      {#if processing}
+        Processing...
+      {:else}
+        Pay
+      {/if}
+    </button>
+  </form>
+</Elements>
 
 <style>
   .error {

--- a/src/routes/examples/klarna/+page.svelte
+++ b/src/routes/examples/klarna/+page.svelte
@@ -77,36 +77,32 @@
   <p class="error">Payment failed. Please try again.</p>
 {/if}
 
-{#if stripe}
-  <form on:submit|preventDefault={submit}>
-    <input
-      name="name"
-      bind:value={name}
-      placeholder="Name"
-      type="text"
-      required
-      disabled={processing}
-    />
-    <input
-      name="email"
-      bind:value={email}
-      placeholder="E-mail"
-      type="email"
-      required
-      disabled={processing}
-    />
+<form on:submit|preventDefault={submit}>
+  <input
+    name="name"
+    bind:value={name}
+    placeholder="Name"
+    type="text"
+    required
+    disabled={processing}
+  />
+  <input
+    name="email"
+    bind:value={email}
+    placeholder="E-mail"
+    type="email"
+    required
+    disabled={processing}
+  />
 
-    <button disabled={processing}>
-      {#if processing}
-        Processing...
-      {:else}
-        Pay with Klarna
-      {/if}
-    </button>
-  </form>
-{:else}
-  Loading...
-{/if}
+  <button disabled={processing}>
+    {#if processing}
+      Processing...
+    {:else}
+      Pay with Klarna
+    {/if}
+  </button>
+</form>
 
 <style>
   .error {

--- a/src/routes/examples/konbini/+page.svelte
+++ b/src/routes/examples/konbini/+page.svelte
@@ -79,44 +79,40 @@
   <p class="error">Payment failed. Please try again.</p>
 {/if}
 
-{#if stripe}
-  <form on:submit|preventDefault={submit}>
-    <input
-      name="name"
-      bind:value={name}
-      placeholder="Name"
-      type="text"
-      required
-      disabled={processing}
-    />
-    <input
-      name="email"
-      bind:value={email}
-      placeholder="E-mail"
-      type="email"
-      required
-      disabled={processing}
-    />
-    <input
-      name="phone"
-      bind:value={phone}
-      placeholder="Phone"
-      type="tel"
-      required
-      disabled={processing}
-    />
+<form on:submit|preventDefault={submit}>
+  <input
+    name="name"
+    bind:value={name}
+    placeholder="Name"
+    type="text"
+    required
+    disabled={processing}
+  />
+  <input
+    name="email"
+    bind:value={email}
+    placeholder="E-mail"
+    type="email"
+    required
+    disabled={processing}
+  />
+  <input
+    name="phone"
+    bind:value={phone}
+    placeholder="Phone"
+    type="tel"
+    required
+    disabled={processing}
+  />
 
-    <button disabled={processing}>
-      {#if processing}
-        Processing...
-      {:else}
-        Pay with Konbini
-      {/if}
-    </button>
-  </form>
-{:else}
-  Loading...
-{/if}
+  <button disabled={processing}>
+    {#if processing}
+      Processing...
+    {:else}
+      Pay with Konbini
+    {/if}
+  </button>
+</form>
 
 <style>
   .error {

--- a/src/routes/examples/payment-element/+page.svelte
+++ b/src/routes/examples/payment-element/+page.svelte
@@ -69,7 +69,7 @@
   <p class="error">{error.message} Please try again.</p>
 {/if}
 
-{#if stripe && clientSecret}
+{#if clientSecret}
   <Elements
     {stripe}
     {clientSecret}

--- a/src/routes/examples/payment-method-messaging/+page.svelte
+++ b/src/routes/examples/payment-method-messaging/+page.svelte
@@ -22,15 +22,11 @@
   >
 </nav>
 
-{#if stripe}
-  <Elements {stripe}>
-    <PaymentMethodMessaging
-      currency="USD"
-      countryCode="US"
-      amount={1000}
-      paymentMethodTypes={['afterpay_clearpay', 'klarna', 'affirm']}
-    />
-  </Elements>
-{:else}
-  Loading...
-{/if}
+<Elements {stripe}>
+  <PaymentMethodMessaging
+    currency="USD"
+    countryCode="US"
+    amount={100000}
+    paymentMethodTypes={['afterpay_clearpay', 'klarna', 'affirm']}
+  />
+</Elements>

--- a/src/routes/examples/payment-request/+page.svelte
+++ b/src/routes/examples/payment-request/+page.svelte
@@ -75,15 +75,11 @@
   <p class="error">{error.message} Please try again.</p>
 {/if}
 
-{#if stripe}
-  <Elements {stripe}>
-    <div class="wrapper">
-      <PaymentRequestButton {paymentRequest} on:paymentmethod={pay} />
-    </div>
-  </Elements>
-{:else}
-  Loading...
-{/if}
+<Elements {stripe}>
+  <div class="wrapper">
+    <PaymentRequestButton {paymentRequest} on:paymentmethod={pay} />
+  </div>
+</Elements>
 
 <style>
   .error {

--- a/src/routes/examples/sepa/+page.svelte
+++ b/src/routes/examples/sepa/+page.svelte
@@ -75,31 +75,27 @@
   <p class="error">{error.message} Please try again.</p>
 {/if}
 
-{#if stripe}
-  <Elements {stripe}>
-    <form on:submit|preventDefault={submit}>
-      <input name="name" bind:value={name} placeholder="Name" disabled={processing} />
-      <input
-        name="email"
-        bind:value={email}
-        placeholder="E-mail"
-        type="email"
-        disabled={processing}
-      />
-      <Iban supportedCountries={['SEPA']} bind:element={ibanElement} classes={{ base: 'input' }} />
+<Elements {stripe}>
+  <form on:submit|preventDefault={submit}>
+    <input name="name" bind:value={name} placeholder="Name" disabled={processing} />
+    <input
+      name="email"
+      bind:value={email}
+      placeholder="E-mail"
+      type="email"
+      disabled={processing}
+    />
+    <Iban supportedCountries={['SEPA']} bind:element={ibanElement} classes={{ base: 'input' }} />
 
-      <button disabled={processing}>
-        {#if processing}
-          Processing...
-        {:else}
-          Pay
-        {/if}
-      </button>
-    </form>
-  </Elements>
-{:else}
-  Loading...
-{/if}
+    <button disabled={processing}>
+      {#if processing}
+        Processing...
+      {:else}
+        Pay
+      {/if}
+    </button>
+  </form>
+</Elements>
 
 <style>
   .error {

--- a/src/routes/examples/sofort/+page.svelte
+++ b/src/routes/examples/sofort/+page.svelte
@@ -77,36 +77,32 @@
   <p class="error">Payment failed. Please try again.</p>
 {/if}
 
-{#if stripe}
-  <form on:submit|preventDefault={submit}>
-    <input
-      name="name"
-      bind:value={name}
-      placeholder="Name"
-      type="text"
-      required
-      disabled={processing}
-    />
-    <input
-      name="email"
-      bind:value={email}
-      placeholder="E-mail"
-      type="email"
-      required
-      disabled={processing}
-    />
+<form on:submit|preventDefault={submit}>
+  <input
+    name="name"
+    bind:value={name}
+    placeholder="Name"
+    type="text"
+    required
+    disabled={processing}
+  />
+  <input
+    name="email"
+    bind:value={email}
+    placeholder="E-mail"
+    type="email"
+    required
+    disabled={processing}
+  />
 
-    <button disabled={processing}>
-      {#if processing}
-        Processing...
-      {:else}
-        Pay with Sofort
-      {/if}
-    </button>
-  </form>
-{:else}
-  Loading...
-{/if}
+  <button disabled={processing}>
+    {#if processing}
+      Processing...
+    {:else}
+      Pay with Sofort
+    {/if}
+  </button>
+</form>
 
 <style>
   .error {

--- a/src/routes/examples/wechat-pay/+page.svelte
+++ b/src/routes/examples/wechat-pay/+page.svelte
@@ -75,27 +75,23 @@
   <p class="error">Payment failed. Please try again.</p>
 {/if}
 
-{#if stripe}
-  <form on:submit|preventDefault={submit}>
-    <input
-      name="email"
-      bind:value={email}
-      placeholder="E-mail"
-      type="email"
-      disabled={processing}
-    />
+<form on:submit|preventDefault={submit}>
+  <input
+    name="email"
+    bind:value={email}
+    placeholder="E-mail"
+    type="email"
+    disabled={processing}
+  />
 
-    <button disabled={processing}>
-      {#if processing}
-        Processing...
-      {:else}
-        Pay with WeChat Pay
-      {/if}
-    </button>
-  </form>
-{:else}
-  Loading...
-{/if}
+  <button disabled={processing}>
+    {#if processing}
+      Processing...
+    {:else}
+      Pay with WeChat Pay
+    {/if}
+  </button>
+</form>
 
 <style>
   .error {


### PR DESCRIPTION
Previously, all examples showed that `<Elements/>` should be wrapped with an `{#if stripe}` condition:

```svelte
{#if stripe}
  <Elements>
    ...
  </Elements>
{/if}
```

The purpose was to ensure the `stripe.elements` instance wasn't accessed server-side.

This PR makes removes the need to do this. Instead, the conditional is inside the `<Elements>` component itself.