### PR TITLE
Fix EmbeddedCheckout IntegrationError: You cannot have multiple Embedded Checkout objects

### DIFF
--- a/src/lib/EmbeddedCheckout.svelte
+++ b/src/lib/EmbeddedCheckout.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { onDestroy } from 'svelte'
   import { register } from './util'
 
   /** @type {import('@stripe/stripe-js').Stripe?} */
@@ -9,6 +10,8 @@
 
   let wrapper
 
+  let checkoutElement
+
   $: if (stripe) {
     register(stripe)
   }
@@ -17,9 +20,14 @@
     stripe
       .initEmbeddedCheckout({ clientSecret })
       .then((element) => {
-        element.mount(wrapper)
+        checkoutElement = element
+        checkoutElement.mount(wrapper)
       })
   }
+
+  onDestroy(() => {
+    checkoutElement?.destroy()
+  });
 </script>
 
 {#if stripe && clientSecret}


### PR DESCRIPTION
## Description
On initial load of the Embedded Checkout element, the element loads correctly. But when you navigate away client-side then navigate back to the page containing the embedded checkout element, you get the error `IntegrationError: You cannot have multiple Embedded Checkout objects`.

## Proposed Solution
This error seems to be an issue with the lifecycle management of the underlying Stripe Embedded Checkout element. The element does provide an interface to destroy it. We can wait for the wrapper element to be destroyed then manually destroy the Stripe Element. This seems to resolve the issue when I tested it locally.

This solution was brought up by github user @conorw.