### PR TITLE
Convert @stripe/stripe-js to a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "format": "prettier --ignore-path .prettierignore --write --plugin-search-dir=. .",
     "semantic-release": "semantic-release"
   },
-  "dependencies": {
-    "@stripe/stripe-js": "^2.4.0"
-  },
   "devDependencies": {
     "@sveltejs/adapter-vercel": "^4.0.5",
     "@sveltejs/kit": "^2.5.5",
@@ -40,6 +37,7 @@
     "vite": "^5.2.8"
   },
   "peerDependencies": {
+    "@stripe/stripe-js": "^3",
     "svelte": "^3 || ^4"
   },
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@stripe/stripe-js':
-    specifier: ^2.4.0
-    version: 2.4.0
+    specifier: ^3
+    version: 3.3.0
   svelte:
     specifier: ^3 || ^4
     version: 4.2.12
@@ -1018,8 +1018,9 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
-  /@stripe/stripe-js@2.4.0:
-    resolution: {integrity: sha512-WFkQx1mbs2b5+7looI9IV1BLa3bIApuN3ehp9FP58xGg7KL9hCHDECgW3BwO9l9L+xBPVAD7Yjn1EhGe6EDTeA==}
+  /@stripe/stripe-js@3.3.0:
+    resolution: {integrity: sha512-dUgAsko9KoYC1U2TIawHzbkQJzPoApxCc1Qf6/j318d1ArViyh6ROHVYTxnU3RlOQL/utUD9I4/QoyiCowsgrw==}
+    engines: {node: '>=12.16'}
     dev: false
 
   /@sveltejs/adapter-vercel@4.0.5(@sveltejs/kit@2.5.5):

--- a/src/routes/+page.md
+++ b/src/routes/+page.md
@@ -17,13 +17,14 @@ Links:
 
 ## Installation
 
-To configure your project, add these 2 packages:
+To configure your project, add these 3 packages:
 
 ```bash
-pnpm install -D stripe svelte-stripe
+pnpm install -D stripe @stripe/stripe-js svelte-stripe
 ```
 
-- [stripe](https://npmjs.org/package/stripe) is the official server-side version of Stripe.
+- [stripe](https://npmjs.org/package/stripe) is Stripe's official server-side library.
+- [@stripe/stripe-js](https://www.npmjs.com/package/@stripe/stripe-js) is Stripe's official client-side library.
 - [svelte-stripe](https://npmjs.org/package/svelte-stripe) is the community-supported wrapper for Stripe Elements.
 
 ## Docs


### PR DESCRIPTION
fixes #110 

- update @stripe/stripe-js to v3 and changes to a dev+peer dep
- update docs to reflect @stripe/stripe-js requirement