### PR TITLE
Add onchange event listener for the link authentication element

### DIFF
--- a/src/lib/LinkAuthenticationElement.svelte
+++ b/src/lib/LinkAuthenticationElement.svelte
@@ -19,6 +19,9 @@
   onMount(() => {
     const options = defaultValues ? { defaultValues } : {}
     element = mount(wrapper, 'linkAuthentication', elements, dispatch, options)
+    element.on('change', (event) => {
+      dispatch('change', event)
+    })
 
     return () => element.destroy()
   })


### PR DESCRIPTION
Allows https://docs.stripe.com/payments/elements/link-authentication-element#retrieving-email-address

There might be a better way to do this but I'm not sure.