### PR TITLE
feat: add missing properties to `Elements`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "semantic-release": "semantic-release"
   },
   "devDependencies": {
-    "@stripe/stripe-js": "^3.3.0",
+    "@stripe/stripe-js": "^5.2.0",
     "@sveltejs/adapter-vercel": "^5.3.0",
     "@sveltejs/kit": "^2.5.7",
     "@sveltejs/package": "^2.3.1",
@@ -39,7 +39,7 @@
     "vite": "^5.2.11"
   },
   "peerDependencies": {
-    "@stripe/stripe-js": "^3 || ^4",
+    "@stripe/stripe-js": "^3 || ^4 || ^5",
     "svelte": "^3 || ^4 || ^5"
   },
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@stripe/stripe-js':
-        specifier: ^3.3.0
-        version: 3.5.0
+        specifier: ^5.2.0
+        version: 5.2.0
       '@sveltejs/adapter-vercel':
         specifier: ^5.3.0
         version: 5.4.6(@sveltejs/kit@2.7.3(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.5)))(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.5)))
@@ -507,8 +507,8 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@stripe/stripe-js@3.5.0':
-    resolution: {integrity: sha512-pKS3wZnJoL1iTyGBXAvCwduNNeghJHY6QSRSNNvpYnrrQrLZ6Owsazjyynu0e0ObRgks0i7Rv+pe2M7/MBTZpQ==}
+  '@stripe/stripe-js@5.2.0':
+    resolution: {integrity: sha512-2ZpEaezx3S0QPtnske175NDaLvUvaVKd4ePHpUN0QF/uV4BBBBRUy5BvQONDym+utbbW0QhSJoiRPnp4FS+4Vg==}
     engines: {node: '>=12.16'}
 
   '@sveltejs/adapter-vercel@5.4.6':
@@ -2841,7 +2841,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@stripe/stripe-js@3.5.0': {}
+  '@stripe/stripe-js@5.2.0': {}
 
   '@sveltejs/adapter-vercel@5.4.6(@sveltejs/kit@2.7.3(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.5)))(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.5)))':
     dependencies:

--- a/src/lib/Elements.svelte
+++ b/src/lib/Elements.svelte
@@ -5,7 +5,7 @@
   /** @type {import('@stripe/stripe-js').Stripe?} */
   export let stripe
 
-  /** @type {StripeElementsOptions["mode"]} */
+  /** @type {import('@stripe/stripe-js').StripeElementsOptionsMode["mode"]} */
   export let mode = undefined
 
   /** @typedef { import('@stripe/stripe-js').Appearance } Appearance */
@@ -22,7 +22,7 @@
   /** @type {Appearance["labels"]} */
   export let labels = 'above'
 
-  /** @typedef { import('@stripe/stripe-js').StripeElementsOptions } StripeElementsOptions */
+  /** @typedef { import('@stripe/stripe-js').StripeElementsOptionsClientSecret & import('@stripe/stripe-js').StripeElementsOptionsMode  } StripeElementsOptions */
 
   /** @type {StripeElementsOptions["loader"]} */
   export let loader = 'auto'
@@ -42,6 +42,30 @@
   /** @type {string?} */
   export let clientSecret = undefined
 
+  /** @type {StripeElementsOptions["paymentMethodTypes"]} */
+  export let paymentMethodTypes = undefined
+
+  /** @type {StripeElementsOptions["setupFutureUsage"]} */
+  export let setupFutureUsage = undefined
+
+  /** @type {StripeElementsOptions["captureMethod"]} */
+  export let captureMethod = undefined
+
+  /** @type {StripeElementsOptions["customerOptions"]} */
+  export let customerOptions = undefined
+
+  /** @type {StripeElementsOptions["externalPaymentMethodTypes"]} */
+  export let externalPaymentMethodTypes = undefined
+
+  /** @type {StripeElementsOptions["paymentMethodConfiguration"]} */
+  export let paymentMethodConfiguration = undefined
+
+  /** @type {StripeElementsOptions["paymentMethodCreation"]} */
+  export let paymentMethodCreation = undefined
+
+  /** @type {StripeElementsOptions["paymentMethodOptions"]} */
+  export let paymentMethodOptions = undefined
+
   $: appearance = {
     theme, variables, rules, labels
   }
@@ -50,7 +74,7 @@
   export let elements = null
 
   $: if (stripe && !elements) {
-    elements = stripe.elements({ mode, currency, amount, appearance, clientSecret, fonts, loader, locale })
+    elements = stripe.elements({ mode, currency, amount, appearance, clientSecret, fonts, loader, locale, paymentMethodTypes, setupFutureUsage, captureMethod, customerOptions, externalPaymentMethodTypes, paymentMethodConfiguration, paymentMethodCreation, paymentMethodOptions })
 
     register(stripe)
     setContext('stripe', { stripe, elements })


### PR DESCRIPTION
Hi,
thanks for the great job on this package! I was missing the `paymentMethodTypes` property on the `Elements` element and thought that while I was at it, I could also just add all other possible properties.

I also changed the allowed stripe sdk version to `5`. I hope this did not break anything.

Best
Hannes 