### PR TITLE
Rename Embedded Checkout initialisation method

### DIFF
--- a/src/lib/EmbeddedCheckout.svelte
+++ b/src/lib/EmbeddedCheckout.svelte
@@ -19,7 +19,7 @@
   onMount(() => {
     register(stripe)
 
-    stripe.initEmbeddedCheckout(options).then((result) => {
+    stripe.createEmbeddedCheckout(options).then((result) => {
       checkout = result
       checkout.mount(wrapper!)
     })


### PR DESCRIPTION
Closes #141 
https://docs.stripe.com/changelog/dahlia/2026-03-25/rename-init-embedded-checkout-to-create-embedded-checkout-page